### PR TITLE
🐛 Fix: 콘텐츠에 diary_id 추가, 엔드포인트 수정, 투두/루틴 목록조회로 수정

### DIFF
--- a/models/diary.js
+++ b/models/diary.js
@@ -49,7 +49,15 @@ class Diary extends Sequelize.Model {
           type: Sequelize.TEXT,
           allowNull: true,
           defaultValue: 0,
-        }
+        },
+        /*question_id: {  // 오늘의 질문 id
+          type: Sequelize.BIGINT,
+          allowNull: true,
+          references: {
+            model: "TodayQuestion",
+            key: "question_id",
+          },
+        },*/
       },
       {
         sequelize,
@@ -71,6 +79,7 @@ class Diary extends Sequelize.Model {
     db.Diary.hasMany(db.Report, { foreignKey: "diary_id", sourceKey: "diary_id", onDelete: "CASCADE" });
     db.Diary.hasMany(db.TodayPlace, { foreignKey: "diary_id", sourceKey: "diary_id", onDelete: "CASCADE" });
     db.Diary.hasMany(db.TodayAnswer,{foreignKey : "diary_id", targetKey: "diary_id", onDelete: "CASCADE"})
+    //db.Diary.belongsTo(db.TodayQuestion, { foreignKey: "question_id", targetKey: "question_id" });
   }
 }
 

--- a/models/today_questions.js
+++ b/models/today_questions.js
@@ -14,11 +14,6 @@ class TodayQuestion extends Sequelize.Model {
           type: Sequelize.TEXT,
           allowNull: false,
         },
-        today_date: {
-          type: Sequelize.DATEONLY, 
-          allowNull: true, 
-          defaultValue: null
-        }
       },
       {
         sequelize,
@@ -38,6 +33,10 @@ class TodayQuestion extends Sequelize.Model {
       sourceKey: "question_id",
       onDelete: "CASCADE",
     });
+    /*db.TodayQuestion.hasMany(db.Diary, {
+      foreignKey: "question_id",
+      sourceKey: "question_id",
+    });*/
   }
 }
 

--- a/routes/contents.js
+++ b/routes/contents.js
@@ -1,40 +1,35 @@
 const express = require('express');
 const router = express.Router();
-const { createTodo,getTodo,updateTodo,deleteTodo,
-        createRoutine,getRoutine,updateRoutine,deleteRoutine,
-        createQuestion, getTodayQuestion,
+const { createTodo,getTodoList,updateTodo,deleteTodo,
+        createRoutine,getRoutineList,updateRoutine,deleteRoutine,
         createAnswer, getAnswer, updateAnswer,deleteAnswer,
-        createPlace, getPlace, updatePlace, deletePlace
+        createPlace, getPlaceList, updatePlace, deletePlace
       }= require('../controllers/content');
 const { verifyToken } = require('../middlewares/jwt');
 const { uploadSingle } = require('../middlewares/upload');
 
 // Todo 
-router.post('/todos', verifyToken, createTodo);
-router.get('/todos/:todo_id', verifyToken, getTodo);
-router.patch('/todos/:todo_id', verifyToken, updateTodo);
-router.delete('/todos/:todo_id', verifyToken, deleteTodo);
-// Routine 
-router.post('/routines', verifyToken, createRoutine);
-router.get('/routines/:routine_id', verifyToken, getRoutine);
-router.patch('/routines/:routine_id', verifyToken, updateRoutine);
-router.delete('/routines/:routine_id', verifyToken, deleteRoutine);
+router.post('/:diary_id/todos', verifyToken, createTodo);
+router.get('/:diary_id/todos', verifyToken, getTodoList);
+router.patch('/:diary_id/:todo_id', verifyToken, updateTodo);
+router.delete('/:diary_id/:todo_id', verifyToken, deleteTodo);
 
-// TodayQuestion
-router.post('/questions', createQuestion);
-// 오늘의 질문 조회
-router.get('/questions/today', getTodayQuestion);
+// Routine 
+router.post('/:diary_id/routines', verifyToken, createRoutine);
+router.get('/:diary_id/routines', verifyToken, getRoutineList);
+router.patch('/:diary_id/:routine_id', verifyToken, updateRoutine);
+router.delete('/:diary_id/:routine_id', verifyToken, deleteRoutine);
 
 // TodayAnswer
-router.post('/questions/:question_id/answers', verifyToken, uploadSingle, createAnswer);
-router.get('/questions/:question_id/answers/:answer_id', verifyToken, getAnswer);
-router.patch('/questions/:question_id/answers/:answer_id', verifyToken, uploadSingle, updateAnswer);
-router.delete('/questions/:question_id/answers/:answer_id', verifyToken, deleteAnswer);
+router.post('/:diary_id/answers', verifyToken, uploadSingle, createAnswer);
+router.get('/:diary_id/answers/:answer_id', verifyToken, getAnswer);
+router.patch('/:diary_id/answers/:answer_id', verifyToken, uploadSingle, updateAnswer);
+router.delete('/:diary_id/answers/:answer_id', verifyToken, deleteAnswer);
 
 //TodayPlace
-router.post('/places', verifyToken, createPlace);
-router.get('/places/:place_id', verifyToken, getPlace);
-router.patch('/places/:place_id', verifyToken, updatePlace);
-router.delete('/places/:place_id', verifyToken, deletePlace);
+router.post('/:diary_id/places', verifyToken, createPlace);
+router.get('/:diary_id/places', verifyToken, getPlaceList);
+router.patch('/:diary_id/places/:place_id', verifyToken, updatePlace);
+router.delete('/:diary_id/places/:place_id', verifyToken, deletePlace);
 
 module.exports = router;

--- a/swagger/swagger-output.json
+++ b/swagger/swagger-output.json
@@ -1674,57 +1674,17 @@
       ]
     }
   },
-
-    "/todos/{todo_id}": {
-      "get": {
-        "summary": "할일 조회",
-        "description": "특정 할 일을 가져옵니다.",
+"/contents/{diary_id}/todos": {
+      "post": {
+        "summary": "투두 생성",
+        "description": "새로운 투두를 생성합니다.",
         "tags": ["Todo"],
         "parameters": [
           {
-            "name": "todo_id",
+            "name": "diary_id",
             "in": "path",
             "required": true,
-            "schema": {
-              "type": "integer",
-              "format": "int64"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "성공적으로 할 일을 가져왔습니다.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Todo"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "할 일을 찾을 수 없습니다."
-          },
-          "500": {
-            "description": "Internal Server Error"
-          },
-          "default": {
-            "description": "기타 오류"
-          }
-        },
-        "security": [
-          { "bearerAuth": [] }
-        ]
-      },
-      "patch": {
-        "summary": "할일 수정",
-        "description": "특정 할 일을 수정합니다.",
-        "tags": ["Todo"],
-        "parameters": [
-          {
-            "name": "todo_id",
-            "in": "path",
-            "required": true,
+            "description": "투두가 속한 다이어리의 ID",
             "schema": {
               "type": "integer",
               "format": "int64"
@@ -1732,31 +1692,144 @@
           }
         ],
         "requestBody": {
+          "required": true,
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/TodoUpdate"
+                "$ref": "#/components/schemas/TodoRequest"
               }
             }
-          },
-          "required": true
+          }
         },
         "responses": {
-          "200": {
-            "description": "성공적으로 할 일이 수정되었습니다.",
+          "201": {
+            "description": "투두가 성공적으로 생성되었습니다.",
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Todo"
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                      "example": "Todo created successfully"
+                    },
+                    "data": {
+                      "$ref": "#/components/schemas/TodoResponse"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "투두 생성 개수 제한을 초과했습니다."
+          },
+          "500": {
+            "description": "서버 오류"
+          }
+        },
+        "security": [
+          { "bearerAuth": [] }
+        ]
+      },
+      "get": {
+        "summary": "투두 목록 조회",
+        "description": "특정 다이어리에 속한 투두 목록을 가져옵니다.",
+        "tags": ["Todo"],
+        "parameters": [
+          {
+            "name": "diary_id",
+            "in": "path",
+            "required": true,
+            "description": "다이어리의 ID",
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "투두 목록 조회 성공",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TodoListResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "서버 오류"
+          }
+        },
+        "security": [
+          { "bearerAuth": [] }
+        ]
+      }
+    },
+    "/contents/{diary_id}/todos/{todo_id}": {
+      "patch": {
+        "summary": "투두 수정",
+        "description": "특정 투두를 수정합니다.",
+        "tags": ["Todo"],
+        "parameters": [
+          {
+            "name": "diary_id",
+            "in": "path",
+            "required": true,
+            "description": "다이어리의 ID",
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          },
+          {
+            "name": "todo_id",
+            "in": "path",
+            "required": true,
+            "description": "수정할 투두의 ID",
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/TodoRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "투두 수정 성공",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                      "example": "Todo updated successfully"
+                    },
+                    "data": {
+                      "$ref": "#/components/schemas/TodoResponse"
+                    }
+                  }
                 }
               }
             }
           },
           "404": {
-            "description": "할 일을 찾을 수 없습니다."
+            "description": "투두를 찾을 수 없습니다."
           },
           "500": {
-            "description": "Internal Server Error"
+            "description": "서버 오류"
           }
         },
         "security": [
@@ -1764,14 +1837,25 @@
         ]
       },
       "delete": {
-        "summary": "할일 삭제",
-        "description": "특정 할 일을 삭제합니다.",
+        "summary": "투두 삭제",
+        "description": "특정 투두를 삭제합니다.",
         "tags": ["Todo"],
         "parameters": [
+          {
+            "name": "diary_id",
+            "in": "path",
+            "required": true,
+            "description": "다이어리의 ID",
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          },
           {
             "name": "todo_id",
             "in": "path",
             "required": true,
+            "description": "삭제할 투두의 ID",
             "schema": {
               "type": "integer",
               "format": "int64"
@@ -1780,48 +1864,26 @@
         ],
         "responses": {
           "200": {
-            "description": "성공적으로 할 일이 삭제되었습니다."
-          },
-          "404": {
-            "description": "할 일을 찾을 수 없습니다."
-          },
-          "500": {
-            "description": "Internal Server Error"
-          }
-        },
-        "security": [
-          { "bearerAuth": [] }
-        ]
-      }
-    },
-    "/todos": {
-      "post": {
-        "summary": "할일 생성",
-        "description": "새로운 할 일을 생성합니다.",
-        "tags": ["Todo"],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/TodoCreate"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "201": {
-            "description": "할 일이 성공적으로 생성되었습니다.",
+            "description": "투두가 성공적으로 삭제되었습니다.",
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Todo"
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                      "example": "Todo deleted successfully"
+                    }
+                  }
                 }
               }
             }
           },
+          "404": {
+            "description": "투두를 찾을 수 없습니다."
+          },
           "500": {
-            "description": "Internal Server Error"
+            "description": "서버 오류"
           }
         },
         "security": [
@@ -1829,56 +1891,121 @@
         ]
       }
     },
-    "/routines/{routine_id}": {
-      "get": {
-        "summary": "루틴 조회",
-        "description": "특정 루틴을 가져옵니다.",
+    "/contents/{diary_id}/routines": {
+      "post": {
+        "summary": "루틴 생성",
+        "description": "특정 다이어리에 새로운 루틴을 생성합니다.",
         "tags": ["Routine"],
         "parameters": [
           {
-            "name": "routine_id",
+            "name": "diary_id",
             "in": "path",
             "required": true,
+            "description": "루틴을 생성할 다이어리의 ID",
             "schema": {
               "type": "integer",
               "format": "int64"
             }
           }
         ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/RoutineRequest"
+              }
+            }
+          }
+        },
         "responses": {
-          "200": {
-            "description": "성공적으로 루틴을 가져왔습니다.",
+          "201": {
+            "description": "루틴이 성공적으로 생성되었습니다.",
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Routine"
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                      "example": "Routine created successfully"
+                    },
+                    "data": {
+                      "$ref": "#/components/schemas/RoutineResponse"
+                    }
+                  }
                 }
               }
             }
           },
-          "404": {
-            "description": "루틴을 찾을 수 없습니다."
+          "400": {
+            "description": "루틴 생성 개수 제한을 초과했습니다."
           },
           "500": {
-            "description": "Internal Server Error"
-          },
-          "default": {
-            "description": "기타 오류"
+            "description": "서버 오류"
           }
         },
         "security": [
           { "bearerAuth": [] }
         ]
       },
+      "get": {
+        "summary": "루틴 목록 조회",
+        "description": "특정 다이어리에 속한 루틴 목록을 가져옵니다.",
+        "tags": ["Routine"],
+        "parameters": [
+          {
+            "name": "diary_id",
+            "in": "path",
+            "required": true,
+            "description": "다이어리의 ID",
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "루틴 목록 조회 성공",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RoutineListResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "서버 오류"
+          }
+        },
+        "security": [
+          { "bearerAuth": [] }
+        ]
+      }
+    },
+    "/contents/{diary_id}/routines/{routine_id}": {
       "patch": {
         "summary": "루틴 수정",
         "description": "특정 루틴을 수정합니다.",
         "tags": ["Routine"],
         "parameters": [
           {
+            "name": "diary_id",
+            "in": "path",
+            "required": true,
+            "description": "다이어리의 ID",
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          },
+          {
             "name": "routine_id",
             "in": "path",
             "required": true,
+            "description": "루틴의 ID",
             "schema": {
               "type": "integer",
               "format": "int64"
@@ -1886,22 +2013,31 @@
           }
         ],
         "requestBody": {
+          "required": true,
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/RoutineUpdate"
+                "$ref": "#/components/schemas/RoutineRequest"
               }
             }
-          },
-          "required": true
+          }
         },
         "responses": {
           "200": {
-            "description": "성공적으로 루틴이 수정되었습니다.",
+            "description": "루틴 수정 성공",
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Routine"
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                      "example": "Routine updated successfully"
+                    },
+                    "data": {
+                      "$ref": "#/components/schemas/RoutineResponse"
+                    }
+                  }
                 }
               }
             }
@@ -1910,7 +2046,7 @@
             "description": "루틴을 찾을 수 없습니다."
           },
           "500": {
-            "description": "Internal Server Error"
+            "description": "서버 오류"
           }
         },
         "security": [
@@ -1923,9 +2059,20 @@
         "tags": ["Routine"],
         "parameters": [
           {
+            "name": "diary_id",
+            "in": "path",
+            "required": true,
+            "description": "다이어리의 ID",
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          },
+          {
             "name": "routine_id",
             "in": "path",
             "required": true,
+            "description": "루틴의 ID",
             "schema": {
               "type": "integer",
               "format": "int64"
@@ -1934,158 +2081,48 @@
         ],
         "responses": {
           "200": {
-            "description": "성공적으로 루틴이 삭제되었습니다."
+            "description": "루틴이 성공적으로 삭제되었습니다.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                      "example": "Routine deleted successfully"
+                    }
+                  }
+                }
+              }
+            }
           },
           "404": {
             "description": "루틴을 찾을 수 없습니다."
           },
           "500": {
-            "description": "Internal Server Error"
-          }
-        },
-        "security": [
-          { "bearerAuth": [] }
-        ]
-      }
-    },
-    "/routines": {
-      "post": {
-        "summary": "루틴 생성",
-        "description": "새로운 루틴을 생성합니다.",
-        "tags": ["Routine"],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/RoutineCreate"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "201": {
-            "description": "루틴이 성공적으로 생성되었습니다.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Routine"
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "Internal Server Error"
-          }
-        },
-        "security": [
-          { "bearerAuth": [] }
-        ]
-      }
-    },
-    "/contents/questions": {
-      "post": {
-        "summary": "오늘의 질문 생성",
-        "tags": ["Today's Q&A"],
-        "description": "새로운 질문을 생성합니다.",
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "properties": {
-                  "question_text": {
-                    "type": "string",
-                    "description": "생성할 질문의 텍스트",
-                    "example": "오늘의 목표는 무엇인가요?"
-                  }
-                },
-                "required": ["question_text"]
-              }
-            }
-          }
-        },
-        "responses": {
-          "201": {
-            "description": "질문이 성공적으로 생성되었습니다.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "message": {
-                      "type": "string",
-                      "example": "질문이 생성되었습니다."
-                    },
-                    "data": {
-                      "$ref": "#/components/schemas/TodayQuestion"
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "서버 오류로 질문 생성에 실패했습니다."
-          },
-          "404": {
-            "description": "요청한 리소스를 찾을 수 없습니다."
-          },
-          "403": {
-            "description": "요청에 대한 권한이 없습니다."
-          },
-          "400": {
-            "description": "잘못된 요청입니다. 요청 데이터를 확인해주세요."
-          }
-        }
-      }
-    },
-    "/contents/questions/today": {
-      "get": {
-        "summary": "오늘의 질문 조회",
-        "tags": ["Today's Q&A"],
-        "description": "하루 동안 고정된 오늘의 질문을 조회합니다.",
-        "responses": {
-          "200": {
-            "description": "오늘의 질문 조회 성공",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "message": {
-                      "type": "string",
-                      "example": "오늘의 질문 조회 성공"
-                    },
-                    "data": {
-                      "$ref": "#/components/schemas/TodayQuestion"
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "500": {
             "description": "서버 오류"
           }
-        }
+        },
+        "security": [
+          { "bearerAuth": [] }
+        ]
       }
     },
-    "/contents/questions/{question_id}/answers": {
-      "post": { 
+    "/contents/{diary_id}/answers": {
+      "post": {
         "summary": "오늘의 답변 등록",
-        "tags": ["Today's Q&A"],
+        "tags": ["Today's Answer"],
         "description": "사용자가 오늘의 질문에 대한 답변을 생성합니다. 사진을 첨부할 수 있습니다.",
         "parameters": [
           {
-            "name": "question_id",
+            "name": "diary_id",
             "in": "path",
             "required": true,
-            "description": "답변을 생성할 질문의 ID",
             "schema": {
-              "type": "integer"
-            }
+              "type": "integer",
+              "format": "int64"
+            },
+            "description": "답변이 속한 다이어리의 ID"
           }
         ],
         "requestBody": {
@@ -2093,19 +2130,7 @@
           "content": {
             "multipart/form-data": {
               "schema": {
-                "type": "object",
-                "properties": {
-                  "answer_text": {
-                    "type": "string",
-                    "description": "사용자가 작성한 답변 내용"
-                  },
-                  "answer_photo": {
-                    "type": "string",
-                    "format": "binary",
-                    "description": "답변과 함께 첨부할 사진 (선택사항)"
-                  }
-                },
-                "required": ["answer_text", "diary_id"]
+                "$ref": "#/components/schemas/TodayAnswerRequest"
               }
             }
           }
@@ -2116,22 +2141,10 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "message": {
-                      "type": "string",
-                      "example": "답변이 등록되었습니다."
-                    },
-                    "data": {
-                      "$ref": "#/components/schemas/TodayAnswer"
-                    }
-                  }
+                  "$ref": "#/components/schemas/TodayAnswerResponse"
                 }
               }
             }
-          },
-          "403": {
-            "description": "이 질문에 답변할 권한이 없습니다."
           },
           "404": {
             "description": "질문을 찾을 수 없습니다."
@@ -2147,47 +2160,40 @@
         ]
       }
     },
-    "/contents/questions/{question_id}/answers/{answer_id}": {
+    "/contents/{diary_id}/answers/{answer_id}": {
       "get": {
         "summary": "오늘의 답변 조회",
-        "tags": ["Today's Q&A"],
+        "tags": ["Today's Answer"],
         "description": "사용자가 특정 질문에 대한 답변을 조회합니다.",
         "parameters": [
           {
-            "name": "question_id",
+            "name": "diary_id",
             "in": "path",
             "required": true,
-            "description": "조회할 답변이 속한 질문의 ID",
             "schema": {
-              "type": "integer"
-            }
+              "type": "integer",
+              "format": "int64"
+            },
+            "description": "답변이 속한 다이어리의 ID"
           },
           {
             "name": "answer_id",
             "in": "path",
             "required": true,
-            "description": "조회할 답변의 ID",
             "schema": {
-              "type": "integer"
-            }
+              "type": "integer",
+              "format": "int64"
+            },
+            "description": "조회할 답변의 ID"
           }
         ],
         "responses": {
           "200": {
-            "description": "답변이 성공적으로 조회되었습니다.",
+            "description": "답변 조회 성공",
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "message": {
-                      "type": "string",
-                      "example": "답변이 조회되었습니다."
-                    },
-                    "data": {
-                      "$ref": "#/components/schemas/TodayAnswer"
-                    }
-                  }
+                  "$ref": "#/components/schemas/TodayAnswerResponse"
                 }
               }
             }
@@ -2207,26 +2213,28 @@
       },
       "patch": {
         "summary": "오늘의 답변 수정",
-        "tags": ["Today's Q&A"],
+        "tags": ["Today's Answer"],
         "description": "사용자가 특정 질문에 대한 기존 답변을 수정합니다. 사진 수정도 가능합니다.",
         "parameters": [
           {
-            "name": "question_id",
+            "name": "diary_id",
             "in": "path",
             "required": true,
-            "description": "수정할 답변이 속한 질문의 ID",
             "schema": {
-              "type": "integer"
-            }
+              "type": "integer",
+              "format": "int64"
+            },
+            "description": "수정할 답변이 속한 다이어리의 ID"
           },
           {
             "name": "answer_id",
             "in": "path",
             "required": true,
-            "description": "수정할 답변의 ID",
             "schema": {
-              "type": "integer"
-            }
+              "type": "integer",
+              "format": "int64"
+            },
+            "description": "수정할 답변의 ID"
           }
         ],
         "requestBody": {
@@ -2234,45 +2242,21 @@
           "content": {
             "multipart/form-data": {
               "schema": {
-                "type": "object",
-                "properties": {
-                  "answer_text": {
-                    "type": "string",
-                    "description": "수정할 답변 텍스트"
-                  },
-                  "answer_photo": {
-                    "type": "string",
-                    "format": "binary",
-                    "description": "수정할 답변 사진 (선택사항)"
-                  }
-                },
-                "required": ["answer_text"]
+                "$ref": "#/components/schemas/TodayAnswerRequest"
               }
             }
           }
         },
         "responses": {
           "200": {
-            "description": "답변이 성공적으로 수정되었습니다.",
+            "description": "답변 수정 성공",
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "message": {
-                      "type": "string",
-                      "example": "답변이 수정되었습니다."
-                    },
-                    "data": {
-                      "$ref": "#/components/schemas/TodayAnswer"
-                    }
-                  }
+                  "$ref": "#/components/schemas/TodayAnswerResponse"
                 }
               }
             }
-          },
-          "403": {
-            "description": "이 답변을 수정할 권한이 없습니다."
           },
           "404": {
             "description": "답변을 찾을 수 없습니다."
@@ -2282,39 +2266,53 @@
           }
         },
         "security": [
-          { "bearerAuth": [] }
+          {
+            "bearerAuth": []
+          }
         ]
       },
       "delete": {
         "summary": "오늘의 답변 삭제",
-        "tags": ["Today's Q&A"],
+        "tags": ["Today's Answer"],
         "description": "사용자가 특정 질문에 대한 답변을 삭제합니다.",
         "parameters": [
           {
-            "name": "question_id",
+            "name": "diary_id",
             "in": "path",
             "required": true,
-            "description": "삭제할 답변이 속한 질문의 ID",
             "schema": {
-              "type": "integer"
-            }
+              "type": "integer",
+              "format": "int64"
+            },
+            "description": "삭제할 답변이 속한 다이어리의 ID"
           },
           {
             "name": "answer_id",
             "in": "path",
             "required": true,
-            "description": "삭제할 답변의 ID",
             "schema": {
-              "type": "integer"
-            }
+              "type": "integer",
+              "format": "int64"
+            },
+            "description": "삭제할 답변의 ID"
           }
         ],
         "responses": {
           "200": {
-            "description": "답변이 성공적으로 삭제되었습니다."
-          },
-          "403": {
-            "description": "이 답변을 삭제할 권한이 없습니다."
+            "description": "답변 삭제 성공",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                      "example": "답변이 삭제되었습니다."
+                    }
+                  }
+                }
+              }
+            }
           },
           "404": {
             "description": "답변을 찾을 수 없습니다."
@@ -2324,75 +2322,57 @@
           }
         },
         "security": [
-          { "bearerAuth": [] }
-        ]
-      }
-    },
-    "/contents/places": {
-      "post": {
-        "summary": "오늘의 장소 등록",
-        "tags": ["Today's Places"],
-        "description": "사용자가 오늘의 장소를 등록합니다. 사용자는 JWT를 통해 인증되며, 장소 등록 시 카테고리 번호, 메모와 기분을 입력할 수 있습니다.",
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/TodayPlace"
-              }
-            }
-          }
-        },
-        "responses": {
-          "201": {
-            "description": "오늘의 장소가 성공적으로 등록되었습니다.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "message": {
-                      "type": "string",
-                      "example": "오늘의 장소가 성공적으로 등록되었습니다."
-                    },
-                    "data": {
-                      "$ref": "#/components/schemas/TodayPlace"
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "Internal Server Error"
-          }
-        },
-        "security": [
           {
             "bearerAuth": []
           }
         ]
       }
     },
-    "/contents/places/{place_id}": {
-      "get": {
-        "summary": "오늘의 장소 조회",
-        "tags": ["Today's Places"],
-        "description": "사용자가 특정 ID에 해당하는 오늘의 장소를 조회합니다.",
+    "/contents/{diary_id}/places": {
+      "post": {
+        "summary": "오늘의 장소 등록",
+        "description": "특정 다이어리에 새로운 장소를 추가합니다.",
+        "tags": ["TodayPlace"],
         "parameters": [
           {
-            "name": "place_id",
+            "name": "diary_id",
             "in": "path",
             "required": true,
-            "description": "조회할 장소의 ID",
             "schema": {
-              "type": "integer"
-            }
+              "type": "integer",
+              "format": "int64"
+            },
+            "description": "다이어리 ID"
           }
         ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "cate_num": {
+                    "type": "integer",
+                    "description": "카테고리 번호"
+                  },
+                  "today_mood": {
+                    "type": "string",
+                    "description": "오늘의 기분"
+                  },
+                  "place_memo": {
+                    "type": "string",
+                    "description": "장소 메모"
+                  }
+                },
+                "required": ["cate_num", "today_mood", "place_memo"]
+              }
+            }
+          }
+        },
         "responses": {
-          "200": {
-            "description": "오늘의 장소 조회 성공",
+          "201": {
+            "description": "오늘의 장소가 성공적으로 생성되었습니다.",
             "content": {
               "application/json": {
                 "schema": {
@@ -2400,7 +2380,7 @@
                   "properties": {
                     "message": {
                       "type": "string",
-                      "example": "오늘의 장소 조회 성공"
+                      "example": "오늘의 장소가 성공적으로 생성되었습니다."
                     },
                     "data": {
                       "$ref": "#/components/schemas/TodayPlace"
@@ -2409,9 +2389,6 @@
                 }
               }
             }
-          },
-          "404": {
-            "description": "장소를 찾을 수 없습니다."
           },
           "500": {
             "description": "Internal Server Error"
@@ -2423,19 +2400,81 @@
           }
         ]
       },
+      "get": {
+        "summary": "장소 목록 조회",
+        "description": "특정 다이어리와 사용자에 대한 모든 장소를 조회합니다.",
+        "tags": ["TodayPlace"],
+        "parameters": [
+          {
+            "name": "diary_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            },
+            "description": "다이어리 ID"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "장소 목록 조회 성공",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                      "example": "장소 목록 조회 성공"
+                    },
+                    "data": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/TodayPlace"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ]
+      }
+    },
+    "/contents/{diary_id}/places/{place_id}": {
       "patch": {
         "summary": "오늘의 장소 수정",
-        "tags": ["Today's Places"],
-        "description": "사용자가 특정 장소의 정보를 수정합니다.",
+        "description": "특정 장소를 수정합니다.",
+        "tags": ["TodayPlace"],
         "parameters": [
+          {
+            "name": "diary_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            },
+            "description": "다이어리 ID"
+          },
           {
             "name": "place_id",
             "in": "path",
             "required": true,
-            "description": "수정할 장소의 ID",
             "schema": {
-              "type": "integer"
-            }
+              "type": "integer",
+              "format": "int64"
+            },
+            "description": "장소 ID"
           }
         ],
         "requestBody": {
@@ -2443,7 +2482,21 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/TodayPlace"
+                "type": "object",
+                "properties": {
+                  "cate_num": {
+                    "type": "integer",
+                    "description": "카테고리 번호"
+                  },
+                  "today_mood": {
+                    "type": "string",
+                    "description": "오늘의 기분"
+                  },
+                  "place_memo": {
+                    "type": "string",
+                    "description": "장소 메모"
+                  }
+                }
               }
             }
           }
@@ -2483,17 +2536,28 @@
       },
       "delete": {
         "summary": "오늘의 장소 삭제",
-        "tags": ["Today's Places"],
-        "description": "사용자가 특정 장소를 삭제합니다.",
+        "description": "특정 장소를 삭제합니다.",
+        "tags": ["TodayPlace"],
         "parameters": [
+          {
+            "name": "diary_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            },
+            "description": "다이어리 ID"
+          },
           {
             "name": "place_id",
             "in": "path",
             "required": true,
-            "description": "삭제할 장소의 ID",
             "schema": {
-              "type": "integer"
-            }
+              "type": "integer",
+              "format": "int64"
+            },
+            "description": "장소 ID"
           }
         ],
         "responses": {
@@ -4242,217 +4306,202 @@
           }
         }
       },
-      "Todo": {
-        "type": "object",
-        "properties": {
-          "todo_id": {
-            "type": "integer",
-            "format": "int64",
-            "description": "할 일 ID"
-          },
-          "diary_id": {
-            "type": "integer",
-            "format": "int64",
-            "description": "연결된 일기 ID"
-          },
-          "description": {
-            "type": "string",
-            "description": "할 일 내용"
-          },
-          "is_completed": {
-            "type": "boolean",
-            "description": "할 일 완료 여부"
-          },
-          "createdAt": {
-            "type": "string",
-            "format": "date-time",
-            "description": "할 일 생성 시각"
-          },
-          "updatedAt": {
-            "type": "string",
-            "format": "date-time",
-            "description": "할 일 수정 시각"
-          }
-        },
-        "required": ["todo_id", "diary_id", "description", "is_completed"]
-      },
-      "TodoCreate": {
-        "type": "object",
-        "properties": {
-          "diary_id": {
-            "type": "integer",
-            "format": "int64",
-            "description": "연결된 일기 ID"
-          },
-          "description": {
-            "type": "string",
-            "description": "할 일 내용"
-          },
-          "is_completed": {
-            "type": "boolean",
-            "description": "할 일 완료 여부",
-            "default": false
-          }
-        },
-        "required": ["diary_id", "description"]
-      },
-      "TodoUpdate": {
+      "TodoRequest": {
         "type": "object",
         "properties": {
           "description": {
             "type": "string",
-            "description": "할 일 내용"
+            "description": "할 일의 내용"
           },
           "is_completed": {
             "type": "boolean",
             "description": "할 일 완료 여부"
           }
-        }
+        },
+        "required": ["description", "is_completed"]
       },
-      "Routine": {
+      "TodoResponse": {
         "type": "object",
         "properties": {
-          "routine_id": {
+          "id": {
             "type": "integer",
-            "format": "int64",
-            "description": "루틴 ID"
-          },
-          "sign_id": {
-            "type": "integer",
-            "format": "int64",
-            "description": "사용자 sign_id"
+            "description": "할 일의 ID"
           },
           "description": {
             "type": "string",
-            "description": "루틴 설명"
+            "description": "할 일의 내용"
           },
           "is_completed": {
             "type": "boolean",
-            "description": "루틴 완료 여부"
+            "description": "할 일 완료 여부"
+          },
+          "diary_id": {
+            "type": "integer",
+            "description": "할 일이 속한 다이어리의 ID"
+          },
+          "sign_id": {
+            "type": "integer",
+            "description": "사용자의 ID"
           },
           "createdAt": {
             "type": "string",
             "format": "date-time",
-            "description": "루틴 생성 시각"
+            "description": "할 일 생성 시간"
           },
           "updatedAt": {
             "type": "string",
             "format": "date-time",
-            "description": "루틴 수정 시각"
+            "description": "할 일 마지막 수정 시간"
           }
-        },
-        "required": ["routine_id", "sign_id", "description", "is_completed"]
+        }
       },
-      "RoutineCreate": {
+      "TodoListResponse": {
         "type": "object",
         "properties": {
-          "sign_id": {
-            "type": "integer",
-            "format": "int64",
-            "description": "사용자 ID"
-          },
-          "description": {
+          "message": {
             "type": "string",
-            "description": "루틴 설명"
+            "example": "투두 목록 조회 성공"
           },
-          "is_completed": {
-            "type": "boolean",
-            "description": "루틴 완료 여부",
-            "default": false
+          "data": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/TodoResponse"
+            }
           }
-        },
-        "required": ["sign_id", "description"]
+        }
       },
-      "RoutineUpdate": {
+      "RoutineRequest": {
         "type": "object",
         "properties": {
           "description": {
             "type": "string",
-            "description": "루틴 설명"
+            "description": "루틴의 내용"
           },
           "is_completed": {
             "type": "boolean",
             "description": "루틴 완료 여부"
           }
-        }
+        },
+        "required": ["description", "is_completed"]
       },
-      "TodayQuestion": {
+      "RoutineResponse": {
         "type": "object",
         "properties": {
-          "question_id": {
+          "id": {
             "type": "integer",
-            "description": "질문 ID"
+            "description": "루틴의 ID"
           },
-          "question_text": {
+          "description": {
             "type": "string",
-            "description": "질문의 내용"
+            "description": "루틴의 내용"
           },
-          "today_date": {
-            "type": "string",
-            "format": "date",
-            "description": "오늘의 질문이 설정된 날짜 (YYYY-MM-DD 형식)"
+          "is_completed": {
+            "type": "boolean",
+            "description": "루틴 완료 여부"
+          },
+          "diary_id": {
+            "type": "integer",
+            "description": "루틴이 속한 다이어리의 ID"
+          },
+          "sign_id": {
+            "type": "integer",
+            "description": "사용자의 ID"
           },
           "createdAt": {
             "type": "string",
             "format": "date-time",
-            "description": "질문이 생성된 시간"
+            "description": "루틴 생성 시간"
           },
           "updatedAt": {
             "type": "string",
             "format": "date-time",
-            "description": "질문이 수정된 시간"
+            "description": "루틴 마지막 수정 시간"
           }
         }
       },
-      "TodayAnswer": {
+      "RoutineListResponse": {
         "type": "object",
         "properties": {
-          "answer_id": {
-            "type": "integer",
-            "description": "답변 ID"
+          "message": {
+            "type": "string",
+            "example": "루틴 목록 조회 성공"
           },
-          "question_id": {
-            "type": "integer",
-            "description": "질문 ID"
-          },
-          "sign_id": {
-            "type": "integer",
-            "description": "사용자 ID"
-          },
+          "data": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/RoutineResponse"
+            }
+          }
+        }
+      },
+      "TodayAnswerRequest": {
+        "type": "object",
+        "properties": {
           "answer_text": {
             "type": "string",
-            "description": "답변 텍스트"
-          },
-          "diary_id": {
-            "type": "integer",
-            "format": "int64",
-            "description": "연결된 일기 ID"
+            "description": "답변 내용",
+            "example": "오늘의 질문에 대한 답변입니다."
           },
           "answer_photo": {
             "type": "string",
             "format": "binary",
-            "description": "첨부된 답변 사진 경로"
+            "description": "답변 사진 파일 (선택 사항)"
+          }
+        }
+      },
+      "TodayAnswerResponse": {
+        "type": "object",
+        "properties": {
+          "answer_id": {
+            "type": "integer",
+            "example": 1
+          },
+          "diary_id": {
+            "type": "integer",
+            "example": 123
+          },
+          "sign_id": {
+            "type": "integer",
+            "example": 456
+          },
+          "answer_text": {
+            "type": "string",
+            "example": "오늘의 질문에 대한 사용자의 답변입니다."
+          },
+          "answer_photo": {
+            "type": "string",
+            "example": "/uploads/photo.jpg"
           },
           "createdAt": {
             "type": "string",
             "format": "date-time",
-            "description": "답변 생성 날짜"
+            "example": "2023-10-25T14:48:00.000Z"
           },
           "updatedAt": {
             "type": "string",
             "format": "date-time",
-            "description": "답변 수정 날짜"
+            "example": "2023-10-26T10:30:00.000Z"
           }
-        },
-        "required": ["answer_id", "question_id", "sign_id", "diary_id", "answer_text"]
+        }
       },
       "TodayPlace": {
         "type": "object",
         "properties": {
           "place_id": {
             "type": "integer",
+            "format": "int64",
             "description": "장소 ID",
             "example": 1
+          },
+          "diary_id": {
+            "type": "integer",
+            "format": "int64",
+            "description": "연결된 일기 ID"
+          },
+          "cate_num": {
+            "type": "integer",
+            "description": "카테고리 번호 (영화관:1, 놀이공원:2 등)",
+            "example": 3
           },
           "today_mood": {
             "type": "string",
@@ -4463,20 +4512,6 @@
             "type": "string",
             "description": "장소에 대한 메모",
             "example": "카페에서 커피마시기"
-          },
-          "cate_num": {
-            "type": "integer",
-            "description": "카테고리 번호 (영화관:1, 놀이공원:2 등)",
-            "example": 3
-          },
-          "sign_id": {
-            "type": "integer",
-            "description": "사용자 ID"
-          },
-          "diary_id": {
-            "type": "integer",
-            "format": "int64",
-            "description": "연결된 일기 ID"
           },
           "createdAt": {
             "type": "string",


### PR DESCRIPTION
1. 콘텐츠 컨트롤러 req.param에 diary_id 추가했습니다.
2. diary_id가 추가됨에 따라 라우터 엔드포인트 전반적으로 수정했습니다. -> 스웨거 반영
3. 투두/루틴/오늘의장소 단일 조회를 list형태의 목록 조회로 수정했습니다.